### PR TITLE
Removing 'subset: v1' from VirtualService to address HTTP 503 errors

### DIFF
--- a/scripts/istio/1-1.vs-client-server.yaml
+++ b/scripts/istio/1-1.vs-client-server.yaml
@@ -14,7 +14,6 @@ spec:
     route:
     - destination:
         host: chat-server
-        subset: v1
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -32,4 +31,3 @@ spec:
     route:
     - destination:
         host: chat-client
-        subset: v1

--- a/scripts/istio/2-1.vs-client-apple-android.yaml
+++ b/scripts/istio/2-1.vs-client-apple-android.yaml
@@ -28,4 +28,3 @@ spec:
   - route:
     - destination:
         host: chat-client
-        subset: v1


### PR DESCRIPTION
Did a little further investigating and found that when I removed `subset: v1` from the VirtualService object, the HTTP 503 errors generated by istio-envoy went away.

Fixes #1 